### PR TITLE
v1.4.5

### DIFF
--- a/game/update.js
+++ b/game/update.js
@@ -1,6 +1,6 @@
 window.noname_update = {
-	version: "1.4.4",
-	update: "1.4.4",
+	version: "1.4.5",
+	update: "1.4.5",
 	changeLog: [
 		"调整了被放逐者鬼牌技能能量扣除时机，以及应战的攻击牌含有命格的问题",
 		"调整了炼金术士的万物湮灭技能的写法，使其法术伤害结算顺序固定为逆时针方向",
@@ -23,8 +23,8 @@ window.noname_update = {
 		"完善设置-选项-技能中禁双角同时出现设置",
 		"将one_damage技能标签改为oneDamage",
 		"优化ai在1点法伤技能中的治疗使用",
-		"优化get.shiQi/zhanJi/xingBei,可直接传入玩家参数"
-
+		"优化get.shiQi/zhanJi/xingBei,可直接传入玩家参数",
+		"修复changeDamageNum和setDamageNum错误删除导致damage事件未适配",
 	],
 	files: [
 

--- a/noname/library/element/gameEvent.js
+++ b/noname/library/element/gameEvent.js
@@ -1344,9 +1344,11 @@ export class GameEvent {
 			this.getParent().num+=num;
 			return this;
 		}
-		if(typeof this.damageNum == 'number'){
+		if(typeof this.damageNum == 'number'|| typeof this.num == 'number'){
 			if(typeof this.damageNum == 'number') this.damageNum += num;
+			if(typeof this.num == 'number') this.num += num;
 			if(this.damageNum < 0) this.damageNum = 0;
+			if(this.num < 0) this.num = 0
 		}else if(typeof this.getParent().damageNum=='number'){
 			this.getParent().damageNum += num;
 			if(this.getParent().damageNum < 0) this.getParent().damageNum = 0;
@@ -1359,8 +1361,9 @@ export class GameEvent {
 			this.getParent().num=num;
 			return this;
 		}
-		if(typeof this.damageNum == 'number'){
+		if(typeof this.damageNum == 'number'|| typeof this.num == 'number'){
 			if(typeof this.damageNum == 'number') this.damageNum = num;
+			if(typeof this.num == 'number') this.num = num;
 		}else if(typeof this.getParent().damageNum=='number'){
 			this.getParent().damageNum = num;
 		}


### PR DESCRIPTION
调整了被放逐者鬼牌技能能量扣除时机，以及应战的攻击牌含有命格的问题
调整了炼金术士的万物湮灭技能的写法，使其法术伤害结算顺序固定为逆时针方向
修正了皇家侍卫的神圣庇护治疗结算时机，使其更符合技能描述
修复了皇家侍卫绝地反击在我方均没有治疗的时候无法发动的问题
修复了心灵塑师发动心灵风暴，同时响应改变世界时，额外增加1点法术伤害结算成2段伤害(1+1)的问题
修正了游侠追风刺的技能名错误问题
修复了战歌祭司放置希望之歌后，可以发动英雄战歌转移希望之歌的问题
战歌祭司的战净歌谣技能调整为自己先摸牌，而后目标对手摸牌，使其更符合技能描述
删除changeDamageNum和setDamageNuml函数以及usecard事件中num相关内容
增加setDamageNum函数
修复修改skillTranslation导致刃技能报错
修复圣弓等圣屑飓暴第一张牌为刃时报错
修复虚弱选项错误设置参数
修复贪婪少女亡女的金库对方士气为1时无法转移士气
可能修复偶发出现的虚弱选项不全问题
修复trick圣弓自动填充宝石效果与描述不符
发动启动附属技能时，去除启动等字，避免日志歧义
修复圣仲裁者天罪应战命中会触发效果
完善设置-选项-技能中禁双角同时出现设置
将one_damage技能标签改为oneDamage 
优化ai在1点法伤技能中的治疗使用
优化get.shiQi\zhanJi\xingBei,可直接传入玩家参数
修复changeDamageNum和setDamageNum错误删除导致damage事件未适配